### PR TITLE
linux desktop entry

### DIFF
--- a/resources/skylobby.desktop
+++ b/resources/skylobby.desktop
@@ -3,5 +3,6 @@ Type=Application
 Name=SkyLobby
 Exec=skylobby
 Icon=skylobby
+Comment=A Spring RTS lobby and replay viewer
 Terminal=false
 Categories=Game

--- a/resources/skylobby.desktop
+++ b/resources/skylobby.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=SkyLobby
+Exec=skylobby
+Icon=skylobby
+Terminal=false
+Categories=Game


### PR DESCRIPTION
Desktop entry for the [free desktop entry spec ](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys)
These files usually reside in /usr/share/applications/ or /usr/local/share/applications/ for applications installed system-wide, or ~/.local/share/applications/ for user-specific applications and are used to make the application show up in the desktop menus.
